### PR TITLE
Improve detection whether SecureBoot is enabled

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -56,7 +56,7 @@ assert_run_as_root() {
 # Terminates the program if UEFI Secure Boot is enabled
 assert_secureboot_disabled() {
     local -r message='Check Secure Boot disabled'
-    if dmesg | grep -P 'secureboot:\s+Secure\s+boot\s+enabled' 1>/dev/null; then
+    if LC_ALL='C' mokutil --sb-state 2>/dev/null | grep -P '^SecureBoot\s+enabled' 1>/dev/null; then
         report_step_error "${message}" 'Secure Boot is not supported yet'
         exit 1
     fi

--- a/test_almalinux-deploy.bats
+++ b/test_almalinux-deploy.bats
@@ -46,19 +46,23 @@ teardown() {
 }
 
 @test 'assert_secureboot_disabled fails on enabled Secure Boot' {
-    function dmesg() {
-        echo '[    0.000000] secureboot: Secure boot enabled'
+    function mokutil() {
+        case "$1" in
+            '--sb-state' ) echo 'SecureBoot enabled' ;;
+        esac
     }
-    export -f dmesg
+    export -f mokutil
     run assert_secureboot_disabled
     [[ ${status} -ne 0 ]]
 }
 
 @test 'assert_secureboot_disabled passes on disabled Secure Boot' {
-    function dmesg() {
-        echo '[    0.000000] secureboot: Secure boot disabled'
+    function mokutil() {
+        case "$1" in
+            '--sb-state' ) echo 'SecureBoot disabled' ;;
+        esac
     }
-    export -f dmesg
+    export -f mokutil
     run assert_secureboot_disabled
     [[ ${status} -eq 0 ]]
 }


### PR DESCRIPTION
As the capacity of the kernel ring buffer is limited, it isn't very
robust to search for a specific string in the output of `dmesg(1)`. The
likelihood the determine the correct state of SecureBoot is extremely
reduced on machines with a high volume of kernel logging. Some examples
given, this can be either per configuration (`iptables(8)` LOG target),
broken hardware (kernel barking all the time because of broken ACPI
tables), or simply by high uptime of the machine.

It might be better to use `mokutil(1)` in this case which is provided
by the RPM of the same name. The existance of `mokutil(1)` can be
safely assumed on relevant machines as its RPM is a dependency of the
`shim-x64` RPM which in turn provides the UEFI bootloader.