### PR TITLE
Fixes failing BATS tests for unsupported distros detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-# This is a basic workflow for shellcheck 
+# This is a basic workflow for shellcheck
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
-      env:
-        SHELLCHECK_OPTS: -e SC2001
+      # env:
+      #   SHELLCHECK_OPTS: -e SC2001
 
 # for more options https://github.com/marketplace/actions/shellcheck
   bats:
@@ -33,5 +33,5 @@ jobs:
         run: sudo apt-get install bats
 
       - uses: actions/checkout@v2
-      - name: Test Bats 
+      - name: Test Bats
         run: bats test_almalinux-deploy.bats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
-      # env:
-      #   SHELLCHECK_OPTS: -e SC2001
 
 # for more options https://github.com/marketplace/actions/shellcheck
   bats:

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -294,6 +294,7 @@ migrate_from_centos() {
                     oracle-backgrounds oracle-logos oracle-indexhtml \
                     oracle-logos-ipa oracle-logos-httpd ; do
         if rpm -q "${pkg_name}" &>/dev/null; then
+            # shellcheck disable=SC2001
             alma_pkg="$(echo $pkg_name | sed 's#centos\|oracle#almalinux#')"
             rpm -e --nodeps "${pkg_name}"
             report_step_done "Remove ${pkg_name} package"

--- a/test_almalinux-deploy.bats
+++ b/test_almalinux-deploy.bats
@@ -4,7 +4,7 @@ source almalinux-deploy.sh
 setup() {
     if [[ ${BATS_TEST_DESCRIPTION} =~ 'get_os_release_var' ]] \
        || [[ ${BATS_TEST_DESCRIPTION} =~ 'get_os_version' ]]; then
-        MOCKED_OS_RELEASE=$(tempfile -d ${BATS_TMPDIR} -p osrel_)
+        MOCKED_OS_RELEASE=$(mktemp -p ${BATS_TMPDIR} osrel_XXXX )
     fi
 }
 
@@ -124,8 +124,8 @@ teardown() {
     done
 }
 
-@test 'assert_supported_system fails on non-centos' {
-    for os_id in 'fedora' 'ol' 'rhel'; do
+@test 'assert_supported_system fails on unsupported distributions' {
+    for os_id in 'fedora' 'rocky' 'virtuozzo'; do
         run assert_supported_system "${os_id}" '8' 'x86_64'
         [[ ${status} -ne 0 ]]
         [[ ${output} =~ 'ERROR' ]]


### PR DESCRIPTION
  - removes global SC2001 exclusion from ShellCheck CI because
    it is required only for a single line
  - replaces tempfile with more portable mktemp function in
    BATS tests