### PR TITLE
Added libblockdev-btrfs to remove_pkgs

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -276,7 +276,7 @@ assert_supported_filesystem() {
         return 0
     fi
 
-    if result=$(df -Th | grep "btrfs" | awk 'NR == 1{print $2}'); then
+    if result=$(df -Th | awk '{print $2}' | grep btrfs); then
         report_step_error "BTRFS is not supported filesystem"
         exit 1
     fi

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -36,7 +36,7 @@ REMOVE_PKGS=("centos-linux-release" "centos-gpg-keys" "centos-linux-repos" \
                 "oraclelinux-release" "oraclelinux-release-el8" \
                 "redhat-release" "redhat-release-eula" \
                 "rocky-release" "rocky-gpg-keys" "rocky-repos" \
-                "rocky-obsolete-packages")
+                "rocky-obsolete-packages" "libblockdev-btrfs")
 
 is_container=0
 

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -272,12 +272,13 @@ EOF
 }
 
 assert_supported_filesystem() {
-    if get_status_of_stage "assert_supported_panel"; then
+    if get_status_of_stage "assert_supported_filesystem"; then
         return 0
     fi
 
-    df -Th | grep btrfs &>/dev/null
-    if [ $? -eq 0 ]; then
+    local result=$(df -Th | grep "btrfs" | awk 'NR == 1{print $2}')
+
+    if [[ "$result" == "btrfs" ]]; then
         report_step_error "BTRFS is not supported filesystem"
         exit 1
     fi

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -275,9 +275,9 @@ assert_supported_filesystem() {
     if get_status_of_stage "assert_supported_filesystem"; then
         return 0
     fi
-
+    local result
     if result=$(df -Th | awk '{print $2}' | grep btrfs); then
-        report_step_error "BTRFS is not supported filesystem"
+        report_step_error "${result} is not supported filesystem"
         exit 1
     fi
     save_status_of_stage "assert_supported_filesystem"

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -271,6 +271,19 @@ EOF
     save_status_of_stage "assert_supported_panel"
 }
 
+assert_supported_filesystem() {
+    if get_status_of_stage "assert_supported_panel"; then
+        return 0
+    fi
+
+    df -Th | grep btrfs &>/dev/null
+    if [ $? -eq 0 ]; then
+        report_step_error "BTRFS is not supported filesystem"
+        exit 1
+    fi
+    save_status_of_stage "assert_supported_filesystem"
+}
+
 # Returns a latest almalinux-release RPM package download URL.
 #
 # $1 - AlmaLinux major version (e.g. 8).
@@ -799,6 +812,7 @@ main() {
     #os_version="$(get_os_release_var 'VERSION_ID')"
     #os_version="${os_version:0:1}"
     assert_supported_system "${os_type}" "${os_version}" "${arch}"
+    assert_supported_filesystem
 
     read -r panel_type panel_version < <(get_panel_info)
     assert_supported_panel "${panel_type}" "${panel_version}"

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -276,9 +276,7 @@ assert_supported_filesystem() {
         return 0
     fi
 
-    local result=$(df -Th | grep "btrfs" | awk 'NR == 1{print $2}')
-
-    if [[ "$result" == "btrfs" ]]; then
+    if result=$(df -Th | grep "btrfs" | awk 'NR == 1{print $2}'); then
         report_step_error "BTRFS is not supported filesystem"
         exit 1
     fi


### PR DESCRIPTION
When we migrate from ol8, appear error with libblockdev-btrfs, which cannot be reinstalled