### PR TITLE
Revert minimal supported version

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -17,7 +17,7 @@ BAK_DIR="/tmp/alternatives_backup"
 ALT_DIR="/etc/alternatives"
 
 # AlmaLinux OS 8.5
-MINIMAL_SUPPORTED_VERSION='8.5'
+MINIMAL_SUPPORTED_VERSION='8.3'
 VERSION='0.1.12'
 
 BRANDING_PKGS=("centos-backgrounds" "centos-logos" "centos-indexhtml" \


### PR DESCRIPTION
During this commit

https://github.com/AlmaLinux/almalinux-deploy/commit/10f59bedc08ebdfdb19fa1cb5b82f823866ef259

the minimal supported version was changed to 8.5. But this is wrong. The purpose of this variable is the minimal supported centos release and not the alma release. So we should revert this commit.