### PR TITLE
Simple automated tests with Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def erecipients = "devel@euro-linux.com"
+def erecipients = "TO_BE_FILLED"
 def ebody = """
 ${currentBuild.fullDisplayName} / ${currentBuild.number}
 Check url: ${currentBuild.absoluteUrl}.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,6 @@ pipeline {
           label 'libvirt'
         }
     }
-    environment {
-    }
     stages {
 	stage("Migrate supported systems to AlmaLinux 8"){
             steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ Check url: ${currentBuild.absoluteUrl}.
 """
 
 def supported_8_machine_names = ["centos8", "generic-rhel8", "oracle8", "rockylinux8"]
+def supported_centos_stream = ["centos8stream"]
 def legacy_8_5_machine_names = ["centos8-5", "oracle8-5", "rockylinux8-5"]
 def legacy_8_4_machine_names = ["centos8-4", "rockylinux8-4"]
 
@@ -15,7 +16,7 @@ pipeline {
         }
     }
     stages {
-	stage("Migrate supported systems to AlmaLinux 8"){
+	stage("Migrate supported stable systems to AlmaLinux 8"){
             steps{
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script{
@@ -35,7 +36,27 @@ pipeline {
                 }
             }
         }
-	stage("Migrate legacy 8.5 systems to AlmaLinux 8"){
+	stage("Migrate supported CentOS Stream to equivalent AlmaLinux"){
+            steps{
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  script{
+                      parallel supported_centos_stream.collectEntries { vagrant_machine -> [ "${vagrant_machine}": {
+                              stage("$vagrant_machine") {
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh -d && sudo poweroff\" || true")
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sleep(120)
+                                  sh("vagrant destroy $vagrant_machine -f")
+                              }
+                          }]
+                      }
+                  }
+                }
+            }
+        }
+	stage("Migrate legacy 8.5 stable systems to AlmaLinux 8"){
             steps{
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script{
@@ -55,7 +76,7 @@ pipeline {
                 }
             }
         }
-	stage("Migrate legacy 8.4 systems to AlmaLinux 8"){
+	stage("Migrate legacy 8.4 stable systems to AlmaLinux 8"){
             steps{
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,8 @@ Check url: ${currentBuild.absoluteUrl}.
 """
 
 def supported_8_machine_names = ["centos8", "generic-rhel8", "oracle8", "rockylinux8"]
-def legacy_8_machine_names = ["centos8-4", "rockylinux8-4"]
+def legacy_8_5_machine_names = ["centos8-5", "oracle8-5", "rockylinux8-5"]
+def legacy_8_4_machine_names = ["centos8-4", "rockylinux8-4"]
 
 pipeline {
     agent {
@@ -34,11 +35,31 @@ pipeline {
                 }
             }
         }
-	stage("Migrate legacy systems to AlmaLinux 8"){
+	stage("Migrate legacy 8.5 systems to AlmaLinux 8"){
             steps{
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script{
-                      parallel legacy_8_machine_names.collectEntries { vagrant_machine -> [ "${vagrant_machine}": {
+                      parallel legacy_8_5_machine_names.collectEntries { vagrant_machine -> [ "${vagrant_machine}": {
+                              stage("$vagrant_machine") {
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh && sudo poweroff\" || true")
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sleep(120)
+                                  sh("vagrant destroy $vagrant_machine -f")
+                              }
+                          }]
+                      }
+                  }
+                }
+            }
+        }
+	stage("Migrate legacy 8.4 systems to AlmaLinux 8"){
+            steps{
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  script{
+                      parallel legacy_8_4_machine_names.collectEntries { vagrant_machine -> [ "${vagrant_machine}": {
                               stage("$vagrant_machine") {
                                   sleep(5 * Math.random())
                                   sh("vagrant up $vagrant_machine")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,10 @@ ${currentBuild.fullDisplayName} / ${currentBuild.number}
 Check url: ${currentBuild.absoluteUrl}.
 """
 
-def supported_8_machine_names = ["centos8", "generic-rhel8", "oracle8", "rockylinux8"]
+def supported_8_machine_names = ["oracle8", "rhel8", "rocky8"]
 def supported_centos_stream = ["centos8stream"]
-def legacy_8_5_machine_names = ["centos8-5", "oracle8-5", "rockylinux8-5"]
-def legacy_8_4_machine_names = ["centos8-4", "rockylinux8-4"]
+def legacy_8_5_machine_names = ["centos8-5", "oracle8-5", "rhel8-5", "rocky8-5"]
+def legacy_8_4_machine_names = ["centos8-4", "oracle8-4", "rhel8-4", "rocky8-4"]
 
 pipeline {
     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                 }
             }
         }
-	stage("Migrate supported systems to AlmaLinux 8"){
+	stage("Migrate legacy systems to AlmaLinux 8"){
             steps{
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                               stage("$vagrant_machine") {
                                   sleep(5 * Math.random())
                                   sh("vagrant up $vagrant_machine")
-                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh -f -v -w && sudo poweroff\" || true")
+                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh && sudo poweroff\" || true")
                                   sleep(5 * Math.random())
                                   sh("vagrant up $vagrant_machine")
                                   sleep(120)
@@ -42,7 +42,7 @@ pipeline {
                               stage("$vagrant_machine") {
                                   sleep(5 * Math.random())
                                   sh("vagrant up $vagrant_machine")
-                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh -f -v -w && sudo poweroff\" || true")
+                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh && sudo poweroff\" || true")
                                   sleep(5 * Math.random())
                                   sh("vagrant up $vagrant_machine")
                                   sleep(120)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,77 @@
+def erecipients = "devel@euro-linux.com"
+def ebody = """
+${currentBuild.fullDisplayName} / ${currentBuild.number}
+Check url: ${currentBuild.absoluteUrl}.
+"""
+
+def supported_8_machine_names = ["centos8", "generic-rhel8", "oracle8", "rockylinux8"]
+def legacy_8_machine_names = ["centos8-4", "rockylinux8-4"]
+
+pipeline {
+    agent {
+        node {
+          label 'libvirt'
+        }
+    }
+    environment {
+    }
+    stages {
+	stage("Migrate supported systems to AlmaLinux 8"){
+            steps{
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  script{
+                      parallel supported_8_machine_names.collectEntries { vagrant_machine -> [ "${vagrant_machine}": {
+                              stage("$vagrant_machine") {
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh -f -v -w && sudo poweroff\" || true")
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sleep(120)
+                                  sh("vagrant destroy $vagrant_machine -f")
+                              }
+                          }]
+                      }
+                  }
+                }
+            }
+        }
+	stage("Migrate supported systems to AlmaLinux 8"){
+            steps{
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  script{
+                      parallel legacy_8_machine_names.collectEntries { vagrant_machine -> [ "${vagrant_machine}": {
+                              stage("$vagrant_machine") {
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sh("vagrant ssh $vagrant_machine -c \"sudo /home/vagrant/almalinux-deploy/almalinux-deploy.sh -f -v -w && sudo poweroff\" || true")
+                                  sleep(5 * Math.random())
+                                  sh("vagrant up $vagrant_machine")
+                                  sleep(120)
+                                  sh("vagrant destroy $vagrant_machine -f")
+                              }
+                          }]
+                      }
+                  }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Pipeline finished'
+        }
+        failure {
+            echo 'Pipeline failed'
+                mail to: erecipients,
+                     subject: "Pipeline failed: ${currentBuild.fullDisplayName}",
+                     body: ebody
+        }
+        always {
+            echo 'Running "vagrant destroy -f"'
+            sh("vagrant destroy -f")
+            cleanWs()
+        }
+    }
+}
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,58 +16,71 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "centos8-4" do |i|
-    i.vm.box = "eurolinux-vagrant/centos-8"
+    i.vm.box = "generic/centos8"
     i.vm.hostname = "centos8-4"
-    i.vm.box_version = "8.4.5"
+    i.vm.box_version = "3.4.6"
   end
 
   config.vm.define "centos8-5" do |i|
-    i.vm.box = "eurolinux-vagrant/centos-8"
+    i.vm.box = "generic/centos8"
     i.vm.hostname = "centos8-5"
-    i.vm.box_version = "8.5.3"
-  end
-
-  config.vm.define "centos8" do |i|
-    i.vm.box = "eurolinux-vagrant/centos-8"
-    i.vm.hostname = "centos8"
+    i.vm.box_version = "3.6.4"
   end
 
   config.vm.define "centos8stream" do |i|
-    i.vm.box = "eurolinux-vagrant/centos-stream-8"
+    i.vm.box = "generic/centos8s"
     i.vm.hostname = "centos8stream"
   end
 
+  config.vm.define "oracle8-4" do |i|
+    i.vm.box = "generic/oracle8"
+    i.vm.hostname = "oracle8-4"
+    i.vm.box_version = "3.4.6"
+  end
+
   config.vm.define "oracle8-5" do |i|
-    i.vm.box = "eurolinux-vagrant/oracle-linux-8"
+    i.vm.box = "generic/oracle8"
     i.vm.hostname = "oracle8-5"
-    i.vm.box_version = "8.5.11"
+    i.vm.box_version = "3.6.4"
   end
 
   config.vm.define "oracle8" do |i|
-    i.vm.box = "eurolinux-vagrant/oracle-linux-8"
+    i.vm.box = "generic/oracle8"
     i.vm.hostname = "oracle8"
   end
 
-  config.vm.define "generic-rhel8" do |i|
+  config.vm.define "rhel8-4" do |i|
     i.vm.box = "generic/rhel8"
-    i.vm.hostname = "generic-rhel8"
+    i.vm.hostname = "rhel8-4"
+    i.vm.box_version = "3.4.6"
   end
 
-  config.vm.define "rockylinux8-4" do |i|
-    i.vm.box = "eurolinux-vagrant/rocky-8"
-    i.vm.hostname = "rockylinux8-4"
-    i.vm.box_version = "8.4.6"
+  config.vm.define "rhel8-5" do |i|
+    i.vm.box = "generic/rhel8"
+    i.vm.hostname = "rhel8-5"
+    i.vm.box_version = "3.6.4"
   end
 
-  config.vm.define "rockylinux8-5" do |i|
-    i.vm.box = "eurolinux-vagrant/rocky-8"
-    i.vm.hostname = "rockylinux8-5"
-    i.vm.box_version = "8.5.11"
+  config.vm.define "rhel8" do |i|
+    i.vm.box = "generic/rhel8"
+    i.vm.hostname = "rhel8"
   end
 
-  config.vm.define "rockylinux8" do |i|
-    i.vm.box = "eurolinux-vagrant/rocky-8"
-    i.vm.hostname = "rockylinux8"
+  config.vm.define "rocky8-4" do |i|
+    i.vm.box = "generic/rocky8"
+    i.vm.hostname = "rocky8-4"
+    i.vm.box_version = "3.4.6"
+  end
+
+  config.vm.define "rocky8-5" do |i|
+    i.vm.box = "generic/rocky8"
+    i.vm.hostname = "rocky8-5"
+    i.vm.box_version = "3.6.4"
+  end
+
+  config.vm.define "rocky8" do |i|
+    i.vm.box = "generic/rocky8"
+    i.vm.hostname = "rocky8"
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "libvirt" do |libvirt|
     libvirt.random_hostname = true
+    libvirt.uri = 'qemu:///system'
   end
 
   config.vm.define "centos8-4" do |i|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,11 @@ Vagrant.configure("2") do |config|
     i.vm.hostname = "centos8"
   end
 
+  config.vm.define "centos8stream" do |i|
+    i.vm.box = "eurolinux-vagrant/centos-stream-8"
+    i.vm.hostname = "centos8stream"
+  end
+
   config.vm.define "oracle8-5" do |i|
     i.vm.box = "eurolinux-vagrant/oracle-linux-8"
     i.vm.hostname = "oracle8-5"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box_check_update = true
+
+  # Disable the builtin syncing functionality and use a file provisioner
+  # instead. This allows us to use RHEL boxes that do not come with rsync or
+  # other easy ways of getting the files into a box.
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.provision :file, source: File.expand_path('../', __FILE__), destination: '/home/vagrant/almalinux-deploy'
+
+  config.vm.provider "libvirt" do |libvirt|
+    libvirt.random_hostname = true
+  end
+
+  config.vm.define "centos8-4" do |i|
+    i.vm.box = "eurolinux-vagrant/centos-8"
+    i.vm.hostname = "centos8-4"
+    i.vm.box_version = "8.4.5"
+  end
+
+  config.vm.define "centos8" do |i|
+    i.vm.box = "eurolinux-vagrant/centos-8"
+    i.vm.hostname = "centos8"
+  end
+
+  config.vm.define "oracle8" do |i|
+    i.vm.box = "eurolinux-vagrant/oracle-linux-8"
+    i.vm.hostname = "oracle8"
+  end
+
+  config.vm.define "generic-rhel8" do |i|
+    i.vm.box = "generic/rhel8"
+    i.vm.hostname = "generic-rhel8"
+  end
+
+  config.vm.define "rockylinux8-4" do |i|
+    i.vm.box = "eurolinux-vagrant/rocky-8"
+    i.vm.hostname = "rockylinux8-4"
+    i.vm.box_version = "8.4.6"
+  end
+
+  config.vm.define "rockylinux8" do |i|
+    i.vm.box = "eurolinux-vagrant/rocky-8"
+    i.vm.hostname = "rockylinux8"
+  end
+
+end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,9 +20,21 @@ Vagrant.configure("2") do |config|
     i.vm.box_version = "8.4.5"
   end
 
+  config.vm.define "centos8-5" do |i|
+    i.vm.box = "eurolinux-vagrant/centos-8"
+    i.vm.hostname = "centos8-5"
+    i.vm.box_version = "8.5.3"
+  end
+
   config.vm.define "centos8" do |i|
     i.vm.box = "eurolinux-vagrant/centos-8"
     i.vm.hostname = "centos8"
+  end
+
+  config.vm.define "oracle8-5" do |i|
+    i.vm.box = "eurolinux-vagrant/oracle-linux-8"
+    i.vm.hostname = "oracle8-5"
+    i.vm.box_version = "8.5.11"
   end
 
   config.vm.define "oracle8" do |i|
@@ -39,6 +51,12 @@ Vagrant.configure("2") do |config|
     i.vm.box = "eurolinux-vagrant/rocky-8"
     i.vm.hostname = "rockylinux8-4"
     i.vm.box_version = "8.4.6"
+  end
+
+  config.vm.define "rockylinux8-5" do |i|
+    i.vm.box = "eurolinux-vagrant/rocky-8"
+    i.vm.hostname = "rockylinux8-5"
+    i.vm.box_version = "8.5.11"
   end
 
   config.vm.define "rockylinux8" do |i|


### PR DESCRIPTION
An automation pipeline has been implemented so you can create a Jenkins job and check let's say each day if the latest release of several Vagrant boxes can be migrated without a hassle - this is especially important in case someone wants to migrate an old system such as CentOS 8.4 to AlmaLinux 8.6 and what might get even tougher to practice in the future - let's say migrate from 8.4 to 8.9.
This doesn't cover all possible combinations and some old Enterprise Linux releases.
This implementation is heavily inspired [by the one by EuroLinux](https://github.com/EuroLinux/eurolinux-migration-scripts). It was meant as a token of appreciation for a case that some people know about already ;). I decided to stick with the boxes provided by EuroLinux since they are regularly updated and it'll be easier to test new Enterprise Linux updates.

Please make sure to change the line `def erecipients = "TO_BE_FILLED"` in Jenkinsfile so you'll be emailed in case the job fails.