### PR TITLE
Remove linux-firmware-core

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -37,6 +37,7 @@ REMOVE_PKGS=("centos-linux-release" "centos-gpg-keys" "centos-linux-repos" \
                 "centos-stream-release" "centos-stream-repos" \
                 "libreport-plugin-rhtsupport" "libreport-rhel" "insights-client" \
                 "libreport-rhel-anaconda-bugzilla" "libreport-rhel-bugzilla" \
+                "linux-firmware-core" \
                 "oraclelinux-release" "oraclelinux-release-el8" \
                 "redhat-release" "redhat-release-eula" \
                 "rocky-release" "rocky-gpg-keys" "rocky-repos" \


### PR DESCRIPTION
A simple one line that makes migration from recent Oracle Linux 8 possible (and will help support Oracle Linux 9 once the scripts support version no. 9)
This resolves https://github.com/AlmaLinux/almalinux-deploy/issues/138