### PR TITLE
Don't update GRUB on systems that don't have grub2-mkconfig binary

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -740,7 +740,7 @@ grub_update() {
     if get_status_of_stage "grub_update"; then
         return 0
     fi
-    if [ $(which grub2-mkconfig) ] ; then
+    if [ "$(which grub2-mkconfig)" ] ; then
         if [ -d /sys/firmware/efi ]; then
             grub2-mkconfig -o /etc/grub2-efi.cfg
         else

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -740,16 +740,12 @@ grub_update() {
     if get_status_of_stage "grub_update"; then
         return 0
     fi
-    if [ -d /sys/firmware/efi ]; then
-        if [ -d /boot/efi/EFI/almalinux ]; then
-            grub2-mkconfig -o /boot/efi/EFI/almalinux/grub.cfg
-        elif [ -d /boot/efi/EFI/centos ]; then
-            grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg
+    if [ $(which grub2-mkconfig) ] ; then
+        if [ -d /sys/firmware/efi ]; then
+            grub2-mkconfig -o /etc/grub2-efi.cfg
         else
-            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+            grub2-mkconfig -o /etc/grub2.cfg
         fi
-    else
-        grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
     save_status_of_stage "grub_update"
 }


### PR DESCRIPTION
Simply don't update GRUB on systems that don't have grub2-mkconfig binary.

I also took care of distinct /boot/efi/EFI/X directories since now grub2-mkconfig outputs to a symlink.

This should resolve https://github.com/AlmaLinux/almalinux-deploy/issues/128