### PR TITLE
Increase stage timeout to 60 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 RETRY = '3'
-TIMEOUT = '20' // Adapt it based on the hardware resources and internet connection speed of your Jenkins agent.
+TIMEOUT = '60' // Adapt it based on the hardware resources and internet connection speed of your Jenkins agent.
 
 pipeline {
     agent {


### PR DESCRIPTION
The 20 minutes timeout per stage is not flexible for the Jenkis agents with different hardware and internet connection speeds. Especially on the legacy versions it can took much more time than 20 minutes. Let's increase it to 60 minutes and see how it works.