### PR TITLE
In downgrade-mode, ssh(1) connections might be denied because of corrupted sss_cache(8) database

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -553,7 +553,9 @@ cleanup_sss_cache() {
     fi
     if [[ "${DOWNGRADE}" == 'YES' ]]; then
         for file in /var/lib/sss/db/cache_*.ldb; do
-           mv -f ${file} ${file}.bak
+	   if [ -f ${file} ]; then
+               mv -f ${file} ${file}.bak
+	   fi
         done
     fi
     save_status_of_stage "cleanup_sss_cache"

--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -546,6 +546,19 @@ restore_issue() {
     save_status_of_stage "restore_issue"
 }
 
+# Cleanup sssd(8) cache
+cleanup_sss_cache() {
+    if get_status_of_stage "cleanup_sss_cache"; then
+        return 0
+    fi
+    if [[ "${DOWNGRADE}" == 'YES' ]]; then
+        for file in /var/lib/sss/db/cache_*.ldb; do
+           mv -f ${file} ${file}.bak
+        done
+    fi
+    save_status_of_stage "cleanup_sss_cache"
+}
+
 # Recursively removes a given directory.
 #
 # $1 - Directory path.
@@ -1183,6 +1196,7 @@ main() {
     restore_module_streams
     restore_alternatives
     restore_issue
+    cleanup_sss_cache
     # don't do this steps if we inside the lxc container
     if [ $is_container -eq 0 ]; then
         install_kernel


### PR DESCRIPTION
If we are downgrading, sss_cache(8) must be removed because BerkeleyDB
version will be lower then actual version and ssh(1) logins might be denied.