### PR TITLE
CI: update actions/checkout to v4 for shellcheck and bats jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
 
@@ -30,6 +30,6 @@ jobs:
       - name: Setup Bats
         run: sudo apt-get install bats
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test Bats
         run: bats test_almalinux-deploy.bats


### PR DESCRIPTION
To fix the warning "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2"