### PR TITLE
CI: check deployment inside containers for various combinations of OSs and platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-# This is a basic workflow for shellcheck
 name: CI
 
 # Controls when the action will run.
@@ -14,6 +13,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # Check bash/sh shell scripts
+  # for more options https://github.com/marketplace/actions/shellcheck
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
@@ -22,7 +23,7 @@ jobs:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
 
-# for more options https://github.com/marketplace/actions/shellcheck
+  # Run bats tests for almalinux-deploy.sh script
   bats:
     name: Bats testing
     runs-on: ubuntu-latest
@@ -33,3 +34,198 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test Bats
         run: bats test_almalinux-deploy.bats
+
+  # Check deployment inside containers for various combinations of OSs and platforms
+  Check:
+    # Run the job manually or if pull request event
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4  # number of jobs that can run simultaneously
+      fail-fast: false # continue other jobs if some of them fail
+
+      matrix:
+        # OSs image:tag
+        image_tag:
+          - "oraclelinux:9"
+          - "rockylinux/rockylinux:9"
+          - "quay.io/centos/centos:stream9"
+          - "redhat/ubi9:latest"
+          - "virtuozzo/vzlinux9:latest"
+          - "oraclelinux:8"
+          - "rockylinux/rockylinux:8"
+          - "quay.io/centos/centos:stream8"
+          - "redhat/ubi8:latest"
+          - "virtuozzo/vzlinux8:latest"
+
+        # Platforms list
+        platform:
+          - linux/amd64
+          - linux/ppc64le
+          - linux/s390x
+          - linux/arm64
+
+        # To exclude from the matrix certain combinations of OS + platform for which there are no images
+        exclude:
+          # VzLinux 9
+        - image_tag: "virtuozzo/vzlinux9:latest"
+          platform: linux/ppc64le
+        - image_tag: "virtuozzo/vzlinux9:latest"
+          platform: linux/s390x
+        - image_tag: "virtuozzo/vzlinux9:latest"
+          platform: linux/arm64
+
+          # VzLinux 8
+        - image_tag: "virtuozzo/vzlinux8:latest"
+          platform: linux/ppc64le
+        - image_tag: "virtuozzo/vzlinux8:latest"
+          platform: linux/s390x
+        - image_tag: "virtuozzo/vzlinux8:latest"
+          platform: linux/arm64
+
+          # Oracle Linux 9
+        - image_tag: "oraclelinux:9"
+          platform: linux/ppc64le
+        - image_tag: "oraclelinux:9"
+          platform: linux/s390x
+
+          # Oracle Linux 8
+        - image_tag: "oraclelinux:8"
+          platform: linux/ppc64le
+        - image_tag: "oraclelinux:8"
+          platform: linux/s390x
+
+          # CentOS Stream 8
+        - image_tag: "quay.io/centos/centos:stream8"
+          platform: linux/s390x
+
+          # Rocky Linux 8
+        - image_tag: "rockylinux/rockylinux:8"
+          platform: linux/ppc64le
+        - image_tag: "rockylinux/rockylinux:8"
+          platform: linux/s390x
+
+    steps:
+
+      - name: Prepare stuff
+        run: |
+          # date stamp
+          date_stamp=$(date -u '+%Y%m%d')
+          echo "date_stamp=${date_stamp}" >> $GITHUB_ENV
+          [ -z "$date_stamp-x" ] && false
+
+          # deploy script options, downgrade if CentOS Stream
+          deploy_options=
+          echo '${{ matrix.image_tag }}' | grep stream > /dev/null && deploy_options='--downgrade'
+          echo "deploy_options=${deploy_options}" >> $GITHUB_ENV
+
+          # [Debug]
+          echo "date_stamp=${date_stamp}"
+          echo "deploy_options=${deploy_options}"
+
+      - name: Enable containerd image store on Docker Engine
+        run: |
+          # Use containerd image store
+          sudo jq '.features |= . + { "containerd-snapshotter": true }' /etc/docker/daemon.json > ./daemon.json.${{ env.date_stamp }} && \
+          sudo mv -f ./daemon.json.${{ env.date_stamp }} /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker info -f '{{ .DriverStatus }}'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            almalinux-deploy.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Create the Dockerfile
+        run: |
+          cat <<'EOF'>Dockerfile
+          FROM ${{ matrix.image_tag }}
+
+          # Set the working directory in the container
+          WORKDIR /
+
+          # Copy the almalinux-deploy.sh into the container
+          COPY almalinux-deploy.sh .
+
+          # Set that we are inside container
+          RUN touch /.dockerenv
+
+          # HACK for Virtuozzo Linux
+          RUN grep Virtuozzo /etc/vzlinux-release 2>&1 >/dev/null \
+          && dnf -y --nogpgcheck update vzlinux-release \
+          || true
+
+          # HACK for CentOS Stream release 8
+          RUN if grep 8 /etc/centos-release | grep Stream 2>&1 >/dev/null; \
+          then \
+            sed -i "s/mirrorlist/#mirrorlist/g" /etc/yum.repos.d/CentOS-*; \
+            sed -i "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*; \
+          else \
+            true; \
+          fi
+
+          # Update system
+          RUN dnf -y clean all && dnf -y update
+
+          # HACK for Virtuozzo Linux 8
+          RUN grep Virtuozzo /etc/vzlinux-release | grep 8 2>&1 >/dev/null \
+          && rm -f /var/lib/rpm/__db* \
+          || true
+
+          # Deploy AlmaLinux
+          RUN bash ./almalinux-deploy.sh ${{ env.deploy_options }}
+
+          # Default CMD
+          CMD ["/bin/bash"]
+          EOF
+
+      - name: Build container and deploy AlmaLinux
+        id: build-container
+        uses: docker/build-push-action@v5
+        with:
+          provenance: false
+          file: "${{ github.workspace }}/Dockerfile"
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: true
+
+      - name: Verify deployment
+        run: |
+          # [Test]
+          platform=${{ matrix.platform }}
+          run_arch=${platform#linux/}
+          al8_gpg_pubkey='3abb34f8-5ffd890e'
+          al9_gpg_pubkey='b86b3716-61e69f29'
+
+          echo "Testing AlmaLinux on ${platform}:"
+          arch=$( docker run --platform=${platform} ${{ steps.build-container.outputs.digest }} /bin/bash -c "uname -m" )
+          case ${arch}${run_arch} in
+            x86_64amd64|ppc64leppc64le|s390xs390x|aarch64arm64)
+              true;;
+            *)
+              echo " - ${run_arch} doesn't match ${arch}" && false ;;
+          esac
+          echo " + ${run_arch} matches ${arch}"
+
+          almalinux_release=$( docker run --platform=${platform} ${{ steps.build-container.outputs.digest }} /bin/bash -c "cat /etc/almalinux-release" )
+          if [[ ${almalinux_release} = *'AlmaLinux release'* ]]; then
+            echo " + ${almalinux_release} matched"
+          else
+            echo " - ${almalinux_release} did not match" && false
+          fi
+
+          gpg_pubkey=$( docker run --platform=${platform} ${{ steps.build-container.outputs.digest }} /bin/bash -c "rpm -q gpg-pubkey | egrep -e '${al8_gpg_pubkey}|${al9_gpg_pubkey}'" )
+          if [ -n "${gpg_pubkey}" ]; then
+            echo " + GPG KEY(s) installed:"
+            echo "${gpg_pubkey}"
+          else
+            echo " - None of ${al8_gpg_pubkey} or ${al9_gpg_pubkey} GPG KEY(s) were installed." && false
+          fi


### PR DESCRIPTION
GitHub Action to run `almalinux-deploy.sh` on:
- OSs: oraclelinux:9, rockylinux:9, quay.io/centos/centos:stream9, redhat/ubi9:latest, virtuozzo/vzlinux9:latest, oraclelinux:8, rockylinux:8, quay.io/centos/centos:stream8, redhat/ubi8:latest, virtuozzo/vzlinux8:latest
- platforms: linux/amd64, linux/ppc64le, linux/s390x, linux/arm64
- force set that we are inside container, create /.dockerenv
- use 'rockylinux/rockylinux:*' instead of official 'rockylinux:*' broken images
- if CentOS Stream 8, switch into vault.centos.org
- if Virtuozzo Linux, update vzlinux-release without GPG checking prior to system upgrade
- if Virtuozzo Linux 8, do 'rm -f /var/lib/rpm/__db*' to fix error: "db5 error(-30969) from dbenv->open"
- tests: docker platform matches machine type; the release string; installed GPG public KEY(s)
- run the job manually or if pull request event
- code clean up

Fixes: #220