### PR TITLE
Support MIRACLE LINUX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,13 @@ jobs:
           - "quay.io/centos/centos:stream9"
           - "redhat/ubi9:latest"
           - "virtuozzo/vzlinux9:latest"
+          - "pastalian/miraclelinux:9"
           - "oraclelinux:8"
           - "rockylinux/rockylinux:8"
           - "quay.io/centos/centos:stream8"
           - "redhat/ubi8:latest"
           - "virtuozzo/vzlinux8:latest"
+          - "pastalian/miraclelinux:8"
 
         # Platforms list
         platform:
@@ -104,6 +106,22 @@ jobs:
           platform: linux/ppc64le
         - image_tag: "rockylinux/rockylinux:8"
           platform: linux/s390x
+
+          # MIRACLE LINUX 9
+        - image_tag: "pastalian/miraclelinux:9"
+          platform: linux/ppc64le
+        - image_tag: "pastalian/miraclelinux:9"
+          platform: linux/s390x
+        - image_tag: "pastalian/miraclelinux:9"
+          platform: linux/arm64
+
+          # MIRACLE LINUX 8
+        - image_tag: "pastalian/miraclelinux:8"
+          platform: linux/ppc64le
+        - image_tag: "pastalian/miraclelinux:8"
+          platform: linux/s390x
+        - image_tag: "pastalian/miraclelinux:8"
+          platform: linux/arm64
 
     steps:
 


### PR DESCRIPTION
Support MIRACLE LINUX → AlmaLinux migration.
Since they do not publish official container images, let CI use unofficial images I created.

I've briefly tested that the migration is working, but let me know if there are any other test cases that need to be performed.