### PR TITLE
CI: update/fix check deployment inside containers for various combinations of OSs and platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ master ]
 
+  schedule:
+    # run every Monmday at 03:00 UTC
+    - cron:  '00 03 1 * *'
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -38,7 +42,7 @@ jobs:
   # Check deployment inside containers for various combinations of OSs and platforms
   Check:
     # Run the job manually or if pull request event
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4  # number of jobs that can run simultaneously

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
   schedule:
     # run every Monmday at 03:00 UTC
-    - cron:  '00 03 1 * *'
+    - cron:  '00 03 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -41,8 +41,8 @@ jobs:
 
   # Check deployment inside containers for various combinations of OSs and platforms
   Check:
-    # Run the job manually or if pull request event
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    # Do not run on push event
+    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4  # number of jobs that can run simultaneously
@@ -197,8 +197,8 @@ jobs:
           # Update system
           RUN dnf -y clean all && dnf -y update
 
-          # HACK for Virtuozzo Linux 8
-          RUN grep Virtuozzo /etc/vzlinux-release | grep 8 2>&1 >/dev/null \
+          # HACK for Virtuozzo, Oracle, Rocky and Red Hat 8
+          RUN grep -E 'Virtuozzo|Red Hat|Rocky' /etc/redhat-release | grep -E '8\.' 2>&1 >/dev/null \
           && rm -f /var/lib/rpm/__db* \
           || true
 


### PR DESCRIPTION
- schedule to run every Monday at 03:00 UTC
- fix the "Verify almalinux-release-latest.rpm package ERROR" issue with removing RPM databse if Virtuozzo, Oracle, Rocky and Red Hat 8 and running 'rm -f /var/lib/rpm/__db*'