### PR TITLE
Enable additional repositories during the upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,9 @@ jobs:
           # Update system
           RUN dnf -y clean all && dnf -y update
 
+          # Install DNF plugin
+          RUN dnf -y install dnf-plugins-core
+
           # HACK for Virtuozzo, Oracle, Rocky and Red Hat 8
           RUN grep -E 'Virtuozzo|Red Hat|Rocky' /etc/redhat-release | grep -E '8\.' 2>&1 >/dev/null \
           && rm -f /var/lib/rpm/__db* \


### PR DESCRIPTION
- check dnf-plugins-core package is installed
- create AlmaLinux to EL repositories mappings
- create list of enabled repositories on source system and store it into /var/run/almalinux-deploy-statuses/repo_list_enabled file
- enable additional respositories for AlmaLinux before distro-sync

CI: install dnf-plugins-core package into each system

Fix: #234