### PR TITLE
Add the 'fips-provider-next' to the list of packages to be removed

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -52,7 +52,8 @@ REMOVE_PKGS=("centos-linux-release" "centos-gpg-keys" "centos-linux-repos" \
                 "rocky-release" "rocky-gpg-keys" "rocky-repos" \
                 "rocky-obsolete-packages" "libblockdev-btrfs" \
                 "vzlinux-release" "vzlinux-gpg-keys" "vzlinux-repos" "vzlinux-obsolete-packages" \
-                "evolution-data-server-ui" "epel-next-release" "openssl-fips-provider" "openssl-fips-provider-so")
+                "evolution-data-server-ui" "epel-next-release" "openssl-fips-provider" "openssl-fips-provider-so" \
+                "fips-provider-next")
 REDHAT_DNF_PLUGINS=("product-id" "subscription-manager" "upload-profile")
 REDHAT_REPO_FILES=("/etc/yum.repos.d/redhat.repo" "/etc/yum.repos.d/ubi.repo")
 REDHAT_RHSM_RPMS=("subscription-manager" "subscription-manager-cockpit" "cockpit" "rhc")


### PR DESCRIPTION
That's to solve CentOS Stream 9 to AlmaLinux 9 migration error:
```
file /usr/lib64/ossl-modules/fips.so from install of openssl-libs-1:3.2.2-6.el9_5.1.x86_64 conflicts with file from package fips-provider-next-1.2.0-2.el9.x86_64
```