### PR TITLE
Update almalinux-deploy.sh

### DIFF
--- a/almalinux-deploy.sh
+++ b/almalinux-deploy.sh
@@ -1268,7 +1268,7 @@ disable_redhat_dnf_plugins() {
 subscription_manager_unregister() {
     local -r os_version="${1%%.*}"
     if get_status_of_stage "subscription_manager_unregister"; then
-         return 0
+        return 0
     fi
     if subscription-manager status >/dev/null 2>&1; then
         if [[ "${os_version}" -lt "10" ]]; then


### PR DESCRIPTION
Changed code in subscription_manager_unregister() to correctly unregister the RHEL subscription on both RHEL 9 and RHEL 10, removing a blocker for migrating from RHEL 10 -> AlmaLinux 10.

Tested on RHEL 9 and RHEL 10 VMs. Since the tool targets EL8/EL9 conversions per the documentation, I haven’t yet validated this on RHEL 8 but am happy to do so if you’d like.

[Link to bug report](https://github.com/AlmaLinux/almalinux-deploy/issues/257)